### PR TITLE
#1 modified add spring-jdbc mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,4 +55,8 @@ sourceSets {
 	// https://mvnrepository.com/artifact/org.projectlombok/lombok
 	// compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.22'
 
+	// https://mvnrepository.com/artifact/org.springframework/spring-jdbc
+	implementation group: 'org.springframework', name: 'spring-jdbc', version: '5.3.15'
+
+
  }


### PR DESCRIPTION
@Kodamayuto2001 
I researched the latest version of Spring JDBC from the mavenCentral repository and added the following to the build.gradle file.
```
implementation group: 'org.springframework', name: 'spring-jdbc', version: '5.3.15'
```

The above is because the following import works correctly.
```
import org.springframework.jdbc.core.JdbcTemplate;
```